### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,4 +1,6 @@
 name: Deploy to Cloudflare Workers
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Jackie264/cloudflare-docker-proxy/security/code-scanning/1](https://github.com/Jackie264/cloudflare-docker-proxy/security/code-scanning/1)

To fix this problem, we should add a `permissions` block to the workflow. The ideal location is at the root level, just below the `name` declaration and before `on:`. This makes the permissions apply to all jobs by default, unless overridden. For deploying code via Cloudflare, the job only needs to check out code, so the only repository permission needed is `contents: read`. No write access, nor additional permissions (e.g., issues, pull-requests) are needed for this workflow, unless there is additional functionality not shown. Therefore, add:

```yaml
permissions:
  contents: read
```

just beneath the workflow name.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
